### PR TITLE
Remove logger setup from typesense-rails.rb

### DIFF
--- a/lib/typesense-rails.rb
+++ b/lib/typesense-rails.rb
@@ -17,8 +17,6 @@ rescue LoadError
 end
 
 require "logger"
-Rails.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
-Rails.logger.level = Logger::INFO
 
 module Typesense
   class NotConfigured < StandardError; end


### PR DESCRIPTION
This setting is causing excessive noise in the development/test environment, as reported in https://github.com/typesense/typesense-rails/issues/2

Since algolia-rails does not include this configuration, I’m removing it here as well. I think it was added by mistake during development, especially since there is already a logger configuration for tests.