### PR TITLE
feat: add configurable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Typesense.configuration = {
     protocol: 'http'     # For Typesense Cloud use https
   }],
   api_key: 'your-api-key',
-  connection_timeout_seconds: 2
+  connection_timeout_seconds: 2,
+  log_level: :info        # Optional: Set logging level (:debug, :info, :warn, :error, :fatal, :unknown)
 }
 ```
 

--- a/lib/typesense-rails.rb
+++ b/lib/typesense-rails.rb
@@ -18,7 +18,7 @@ end
 
 require "logger"
 Rails.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
-Rails.logger.level = Logger::INFO
+Rails.logger.level = Logger::WARN
 
 module Typesense
   class NotConfigured < StandardError; end

--- a/lib/typesense-rails.rb
+++ b/lib/typesense-rails.rb
@@ -269,7 +269,7 @@ module Typesense
             metadata ? { "metadata" => metadata } : {}
           )
       )
-      Rails.logger.info "Collection '#{collection_name}' created!"
+      Rails.logger.debug "Collection '#{collection_name}' created!"
 
       typesense_multi_way_synonyms(collection_name, multi_way_synonyms) if multi_way_synonyms
 
@@ -542,7 +542,7 @@ module Typesense
         end
         jsonl_object = documents.join("\n")
         ImportJob.perform(jsonl_object, collection_obj[:alias_name], batch_size)
-        Rails.logger.info "#{objects.length} objects enqueued for import into #{collection_obj[:collection_name]}"
+        Rails.logger.debug "#{objects.length} objects enqueued for import into #{collection_obj[:collection_name]}"
       end
       nil
     end
@@ -557,7 +557,7 @@ module Typesense
         end
         jsonl_object = documents.join("\n")
         import_documents(jsonl_object, "upsert", collection_obj[:alias_name], batch_size: batch_size)
-        Rails.logger.info "#{objects.length} objects upserted into #{collection_obj[:collection_name]}!"
+        Rails.logger.debug "#{objects.length} objects upserted into #{collection_obj[:collection_name]}!"
       end
       nil
     end
@@ -613,7 +613,7 @@ module Typesense
         rescue Typesense::Error::ObjectNotFound => e
           Rails.logger.error "Object #{object_id} could not be removed from #{collection_obj[:collection_name]} collection! Use reindex to update the collection."
         end
-        Rails.logger.info "Removed document with object id '#{object_id}' from #{collection_obj[:collection_name]}"
+        Rails.logger.debug "Removed document with object id '#{object_id}' from #{collection_obj[:collection_name]}"
       end
       nil
     end
@@ -626,7 +626,7 @@ module Typesense
         collection_obj = typesense_ensure_init(options, settings, false)
 
         delete_collection(collection_obj[:alias_name])
-        Rails.logger.info "Deleted #{collection_obj[:alias_name]} collection!"
+        Rails.logger.debug "Deleted #{collection_obj[:alias_name]} collection!"
         @typesense_indexes[settings] = nil
       end
       nil

--- a/lib/typesense/config.rb
+++ b/lib/typesense/config.rb
@@ -11,11 +11,37 @@ module Typesense
 
     def configuration=(configuration)
       @@pagination_backend = configuration[:pagination_backend] if configuration.key?(:pagination_backend)
+      @@log_level = configuration[:log_level] if configuration.key?(:log_level)
       @@configuration = configuration
+      
+      Rails.logger.level = log_level_to_const(configuration[:log_level])
     end
 
     def pagination_backend
       @@pagination_backend
+    end
+
+    def log_level
+      @@log_level
+    end
+
+    def log_level_to_const(level)
+      case level
+      when :debug
+        Logger::DEBUG
+      when :info
+        Logger::INFO
+      when :warn
+        Logger::WARN
+      when :error
+        Logger::ERROR
+      when :fatal
+        Logger::FATAL
+      when :unknown
+        Logger::UNKNOWN
+      else
+        Logger::WARN # default fallback
+      end
     end
 
     def client


### PR DESCRIPTION
## Change Summary
Expand on #11 to include a configurable log level parameter when configuring the gem, instead of removing loggin outright. Default log level to warn.

closes #2 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
