### PR TITLE
Fix pagy config

### DIFF
--- a/lib/typesense/pagination/pagy.rb
+++ b/lib/typesense/pagination/pagy.rb
@@ -10,7 +10,7 @@ module Typesense
         vars = {
           count: total_hits,
           page: options[:page],
-          items: options[:per_page]
+          limit: options[:per_page]
         }
 
         pagy_version = Gem::Version.new(::Pagy::VERSION)


### PR DESCRIPTION
Pagy expects `limit` option instead of `items`.

Reference: https://ddnexus.github.io/pagy/docs/api/pagy/#variables-1