### PR TITLE
fix: expose total hits for pagy to use

### DIFF
--- a/lib/typesense-rails.rb
+++ b/lib/typesense-rails.rb
@@ -684,6 +684,10 @@ module Typesense
         @typesense_json["facet_counts"]
       end
 
+      def total_hits
+        @typesense_json["found"]
+      end
+
       private
 
       def typesense_init_raw_answer(json)


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Pagy's `typesense` paginator relies on `total_hits`, which isn't exposed without a pagination backend, but that pagination backend shouldn't be defined for #17 's usecase.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
