### PR TITLE
fix: resolve top-level model constants from Object

### DIFF
--- a/lib/typesense-rails.rb
+++ b/lib/typesense-rails.rb
@@ -955,11 +955,11 @@ module Typesense
     def typesense_full_const_get(name)
       list = name.split("::")
       list.shift if list.first.blank?
-      obj = Object.const_defined?(:RUBY_VERSION) && RUBY_VERSION.to_f < 1.9 ? Object : self
+      obj = Object
       list.each do |x|
         # This is required because const_get tries to look for constants in the
         # ancestor chain, but we only want constants that are HERE
-        obj = obj.const_defined?(x) ? obj.const_get(x) : obj.const_missing(x)
+        obj = obj.const_defined?(x, false) ? obj.const_get(x, false) : obj.const_missing(x)
       end
       obj
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -73,6 +73,9 @@ ActiveRecord::Schema.define do
     t.string :short_name
     t.integer :hex
   end
+  create_table :collections do |t|
+    t.string :name
+  end
   create_table :namespaced_models do |t|
     t.string :name
     t.integer :another_private_value
@@ -209,6 +212,14 @@ class Color < ActiveRecord::Base
 
   def will_save_change_to_short_name?
     false
+  end
+end
+
+class Collection < ActiveRecord::Base
+  include Typesense
+
+  typesense auto_index: false, index_name: safe_index_name("Collection") do
+    attribute :name
   end
 end
 
@@ -639,6 +650,35 @@ describe "Namespaced::Model" do
     results = Namespaced::Model.search("*", "", { "filter_by" => "customAttr:45" })
     expect(results.size).to eq(1)
     expect(results[0].id).to eq(m.id)
+  end
+end
+
+describe "Collection" do
+  it "resolves the model class instead of Typesense::Collection" do
+    expect(Collection.typesense_options[:type]).to eq(Collection)
+  end
+
+  it "uses the ActiveRecord model when loading search hits" do
+    record = Collection.create!(name: "Archive")
+
+    allow(Collection).to receive(:typesense_raw_search).and_return(
+      {
+        "hits" => [
+          {
+            "document" => { "id" => record.id.to_s },
+            "highlights" => []
+          }
+        ],
+        "found" => 1,
+        "page" => 1,
+        "request_params" => { "per_page" => 10 }
+      }
+    )
+
+    results = Collection.search("*", "name")
+
+    expect(results.length).to eq(1)
+    expect(results.first).to eq(record)
   end
 end
 


### PR DESCRIPTION
## Change Summary
- make `typesense_full_const_get` avoid resolving `Collection` as `Typesense::Collection`
- add an integration regression spec for a top-level `Collection` model and search result loading
- fix #20 

<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
