### PR TITLE
chore: bump version to 1.0.0.rc8

### DIFF
--- a/lib/typesense/version.rb
+++ b/lib/typesense/version.rb
@@ -1,3 +1,3 @@
 module Typesense
-  GEM_VERSION = "1.0.0.rc7"
+  GEM_VERSION = "1.0.0.rc8"
 end


### PR DESCRIPTION
## Summary

- Bumps `GEM_VERSION` from `1.0.0.rc7` to `1.0.0.rc8`

PR #24 (merged in 38c4932) shipped two bug fixes — preserving the live collection until the alias swap during reindex, and making temporary reindex collection names unique — but the gem version was not bumped and no new tag was created.

This PR adds the missing version bump so the fixes can be released to RubyGems.

## For maintainers — release checklist

After merging, to publish the new version:

```bash
git tag v1.0.0.rc8
git push origin v1.0.0.rc8
bundle exec rake release
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)